### PR TITLE
Fix empty result from query select

### DIFF
--- a/src/bumerang/error.py
+++ b/src/bumerang/error.py
@@ -3,6 +3,22 @@ class BumerangError(Exception):
     pass
 
 
+class InvalidIDConstraintError(BumerangError):
+
+    def __init__(self, id):
+        super().__init__()
+        self._id = id
+
+    def __repr__(self):
+        return 'InvalidIDConstraintError(%r)' % self._id
+
+    def __str__(self):
+        return (
+            'Invalid ID Constraint Error: More than one record with the id'
+            ' {id}'.format(id=self._id)
+        )
+
+
 class InvalidRecordError(BumerangError):
 
     def __init__(self, msg):

--- a/test/db/test_borrowrequestrepo.py
+++ b/test/db/test_borrowrequestrepo.py
@@ -1,9 +1,12 @@
 from bumerang.db.borrowrequestrepo import BorrowRequestRepo
 from bumerang.db.databasequery import DatabaseQuery
+from bumerang.error import InvalidIDConstraintError
 from bumerang.request.hydrator import Hydrator
 
 from pytest import fixture as _fixture
+from pytest import raises as _raises
 
+from unittest.mock import Mock as _Mock
 from unittest.mock import patch as _patch
 from unittest.mock import sentinel as _s
 
@@ -14,17 +17,46 @@ def borrow_repo():
 
 
 @_patch.object(Hydrator, 'to_borrow_request', return_value=_s.borrow_request)
-@_patch.object(DatabaseQuery, 'select', return_value=[(_s.id,)])
+@_patch.object(Hydrator, '__init__', return_value=None)
+@_patch.object(DatabaseQuery, 'select', return_value=[_s.record])
 @_patch.object(DatabaseQuery, '__init__', return_value=None)
-def test_find_one_by_id(db_query, select, to_borrow_request, borrow_repo):
+def test_find_one_by_id(
+        db_query, select, hydrator,
+        to_borrow_request, borrow_repo):
+    """Test basic functionality"""
     res = borrow_repo.find_one_by_id(_s.id)
 
     db_query.assert_called_once_with(_s.db)
-    to_borrow_request.call_count == 1, 'wrong amount of calls'
-
     (_, select_id_arg,) = select.call_args[0]
     assert select_id_arg.get('id') == _s.id, \
-        'the query select returned the wrong result'
+        'the query select was called with the wrong id'
+
+    hydrator.assert_called_once_with(_s.record)
 
     assert res == _s.borrow_request, \
         'wrong return value, expected _s.id, got{}'.format(res)
+
+
+@_patch.object(DatabaseQuery, 'select', return_value=[])
+@_patch.object(DatabaseQuery, '__init__', return_value=None)
+def test_find_one_by_id_returns_zero(db_query, select, borrow_repo):
+    """Test that an empty result causes a zero result"""
+    res = borrow_repo.find_one_by_id(_s.id)
+
+    db_query.assert_called_once_with(_s.db)
+    (_, select_id_arg,) = select.call_args[0]
+    assert select_id_arg.get('id') == _s.id, \
+        'the query select was called with the wrong id'
+
+    assert res == None
+
+
+@_patch.object(DatabaseQuery, 'select',
+    return_value=[_s.record1,  _s.record2]
+)
+@_patch.object(DatabaseQuery, '__init__', return_value=None)
+def test_find_one_by_id_raises_InvalidIDConstraintError(
+        db_query, select, borrow_repo):
+    """Test that multiple results raises an error"""
+    with _raises(InvalidIDConstraintError):
+        borrow_repo.find_one_by_id(_s.id)


### PR DESCRIPTION
When the query selected returned an empty list, the assert that assumed the
result had to be exacly one failed for a given id. The logic here is there for
a given unique id, less or more then one results should be returned, but only
one was accounted for here. Added error handling as opposed to an assert so the
endpoint returns an error message instead of crashing. fixes #30 