### PR TITLE
Add request delete end point

### DIFF
--- a/src/bumerang/db/borrowrequestrepo.py
+++ b/src/bumerang/db/borrowrequestrepo.py
@@ -62,7 +62,6 @@ class BorrowRequestRepo:
         else:
             return None
 
-
     def find_requests_by_recent(self, num_requests):
         """ Finds the most recently created requests
 
@@ -87,7 +86,6 @@ class BorrowRequestRepo:
         else:
             return None
 
-
     def insert_one(self, borrow_node):
         """Creates a new borrow_request
 
@@ -99,10 +97,25 @@ class BorrowRequestRepo:
         """
         query = DatabaseQuery(self._db)
         record = query.insert("""
-            INSERT INTO {table} (TITLE, USER_ID, DESCRIPTION, DISTANCE, DURATION, REQUEST_TYPE)
-            VALUES (%(title)s, %(user_id)s, %(description)s, %(distance)s, %(duration)s, %(request_type)s)
+            INSERT INTO {table}
+            (TITLE, USER_ID, DESCRIPTION, DISTANCE, DURATION, REQUEST_TYPE)
+            VALUES (
+                %(title)s, %(user_id)s, %(description)s,
+                %(distance)s, %(duration)s, %(request_type)s
+            )
             RETURNING ID, TITLE
         """.format(table=self._table), borrow_node
         )
 
         return record
+
+    def remove_one_by_id(self, delete_id):
+        query = DatabaseQuery(self._db)
+        record = query.delete("""
+            DELETE FROM {table}
+            WHERE id = %(id)s
+            RETURNING ID
+        """.format(table=self._table), {'id': delete_id}
+        )
+
+        return record[0] if record else None

--- a/src/bumerang/db/databasecreator.py
+++ b/src/bumerang/db/databasecreator.py
@@ -61,7 +61,7 @@ class DatabaseCreator:
             CREATE TABLE IF NOT EXISTS br_offer(
                 ID SERIAL PRIMARY KEY,
                 PROFILE_ID INT REFERENCES br_profile NOT NULL,
-                BORROW_ID INT REFERENCES br_request NOT NULL
+                BORROW_ID INT NOT NULL REFERENCES br_request ON DELETE CASCADE
             )
         """)
 

--- a/src/bumerang/error.py
+++ b/src/bumerang/error.py
@@ -32,6 +32,19 @@ class InvalidRecordError(BumerangError):
         return 'Invalid Record Error: {msg}'.format(msg=self._msg)
 
 
+class InvalidRequestTypeError(BumerangError):
+
+    def __init__(self, req_type):
+        super().__init__()
+        self._req_type = req_type
+
+    def __repr__(self):
+        return 'InvalidRequestTypeError(%r)' % self._req_type
+
+    def __str__(self):
+        return 'Invalid Request Type {}'.format(self._req_type)
+
+
 class InvalidQueryError(BumerangError):
 
     def __init__(self, msg):


### PR DESCRIPTION
Added the request delete end point. The db schema for offers had to be updated
to allow cascading on delete (offer deletes if it references a request being
deleted, which makes sense for our use cases). Fixes #29 