### PR TITLE
Make offer fks unique

### DIFF
--- a/src/bumerang/db/databasecreator.py
+++ b/src/bumerang/db/databasecreator.py
@@ -62,6 +62,7 @@ class DatabaseCreator:
                 ID SERIAL PRIMARY KEY,
                 PROFILE_ID INT REFERENCES br_profile NOT NULL,
                 BORROW_ID INT NOT NULL REFERENCES br_request ON DELETE CASCADE
+                UNIQUE (PROFILE_ID, BORROW_ID)
             )
         """)
 


### PR DESCRIPTION
Make the offer borrow_id and profile_id pairs unique so that the same person
cannot accept a request more than once, while a previous offer still exists. fixes #63 